### PR TITLE
Save items patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 *.user
+.vs
 packages
 Releases
 **/bin

--- a/Plugin/src/Patches/OutOfBoundsItemsFix.cs
+++ b/Plugin/src/Patches/OutOfBoundsItemsFix.cs
@@ -69,6 +69,11 @@ internal class OutOfBoundsItemsFix
     private static IEnumerable<CodeInstruction> SaveItemsCorrectly(IEnumerable<CodeInstruction> instructions,
         ILGenerator ilGenerator)
     {
+        /* Don't patch if this is disabled to avoid conflict with ShaosilGaming's GeneralImprovements mod which
+         * also patches SaveItemsInShip to save the items rotation in the save data (FixItemsLoadingSameRotation). */
+        if (!MattyFixes.PluginConfig.OutOfBounds.Enabled.Value)
+            return instructions;
+
         var codes = instructions.ToList();
         var newOffsetMethod = AccessTools.Method(typeof(OutOfBoundsItemsFix), nameof(ApplyVerticalOffset));
         var getTransformMethod = AccessTools.Property(typeof(Component), nameof(Component.transform)).GetMethod;
@@ -103,9 +108,6 @@ internal class OutOfBoundsItemsFix
 
     private static Vector3 ApplyVerticalOffset(GrabbableObject grabbable, Vector3 position)
     {
-        if (!MattyFixes.PluginConfig.OutOfBounds.Enabled.Value)
-            return position;
-        
         if (grabbable.isHeld || grabbable.isHeldByEnemy || !grabbable.hasHitGround)
             return position;
 


### PR DESCRIPTION
This small PR makes [SaveItemsCorrectly](https://github.com/mattymatty97/LTC_MattyFixes/blob/e952745c2805686e0c950dfa8b222c43f0681f8c/Plugin/src/Patches/OutOfBoundsItemsFix.cs#L69) exit earlier when `OutOfBounds.enabled` is `false`, thus not changing the original function's opcodes at all. 
This allows the [`FixItemsLoadingSameRotation` patch](https://github.com/Shaosil/LethalCompanyMods-GeneralImprovements/blob/d16be720797d84a937be1291666f81dcffd02611/Patches/GameNetworkManagerPatch.cs#L109) in [Shaosil's GeneralImprovements mod](https://github.com/Shaosil/LethalCompanyMods-GeneralImprovements/tree/master) to work properly.

The only downside of moving the check to `SaveItemsCorrectly` is now the user has to reboot the game after changing the `OutOfBounds.enabled` setting.