### PR TITLE
Save items patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 *.user
+.vs
 packages
 Releases
 **/bin

--- a/Plugin/src/Patches/OutOfBoundsItemsFix.cs
+++ b/Plugin/src/Patches/OutOfBoundsItemsFix.cs
@@ -69,6 +69,20 @@ internal class OutOfBoundsItemsFix
     private static IEnumerable<CodeInstruction> SaveItemsCorrectly(IEnumerable<CodeInstruction> instructions,
         ILGenerator ilGenerator)
     {
+        /* Don't patch when this is disabled to avoid conflict with ShaosilGaming's GeneralImprovements mod which
+         * also patches SaveItemsInShip to save the items rotation in the save data (FixItemsLoadingSameRotation). */
+        if (!MattyFixes.PluginConfig.OutOfBounds.Enabled.Value)
+        {
+            MattyFixes.Log.LogDebug("GameNetworkManager.SaveItemsInShip NOT patched (enabled = false)");
+            return instructions;
+        }
+
+        if (!MattyFixes.PluginConfig.OutOfBounds.SaveItemsInShip.Value)
+        {
+            MattyFixes.Log.LogDebug("GameNetworkManager.SaveItemsInShip NOT patched (save_items_in_ship = false)");
+            return instructions;
+        }
+
         var codes = instructions.ToList();
         var newOffsetMethod = AccessTools.Method(typeof(OutOfBoundsItemsFix), nameof(ApplyVerticalOffset));
         var getTransformMethod = AccessTools.Property(typeof(Component), nameof(Component.transform)).GetMethod;
@@ -87,7 +101,7 @@ internal class OutOfBoundsItemsFix
 
         if (matcher.IsInvalid)
         {
-            MattyFixes.Log.LogError("Cannot patch SaveItemsInShip");
+            MattyFixes.Log.LogError("Cannot patch SaveItemsInShip (IL not found)");
             MattyFixes.Log.LogDebug(string.Join("\n", codes));
             return codes;
         }
@@ -97,7 +111,7 @@ internal class OutOfBoundsItemsFix
         matcher.Advance(3);
         matcher.Insert(new CodeInstruction(OpCodes.Call, newOffsetMethod));
 
-        MattyFixes.Log.LogDebug("SaveItemsInShip Patched");
+        MattyFixes.Log.LogDebug("GameNetworkManager.SaveItemsInShip patched");
         return matcher.Instructions();
     }
 
@@ -105,7 +119,10 @@ internal class OutOfBoundsItemsFix
     {
         if (!MattyFixes.PluginConfig.OutOfBounds.Enabled.Value)
             return position;
-        
+
+        if (!MattyFixes.PluginConfig.OutOfBounds.SaveItemsInShip.Value)
+            return position;
+
         if (grabbable.isHeld || grabbable.isHeldByEnemy || !grabbable.hasHitGround)
             return position;
 

--- a/Plugin/src/PluginConfig.cs
+++ b/Plugin/src/PluginConfig.cs
@@ -52,9 +52,12 @@ internal partial class MattyFixes
                 , "y offset for items on the ground\nDictionary Format: '[key]:[value],[key2]:[value2]'\neg: `Vanilla/Ammo:0.0`");
             //OutOfBounds
             OutOfBounds.Enabled = config.Bind("OutOfBounds", "enabled", true
-                , "prevent items from falling below the ship");
+                , "Whether to allow the fixes below, or disable them all at once");
+            OutOfBounds.SaveItemsInShip = config.Bind("OutOfBounds", "save_items_in_ship", true
+                , "Prevent items from falling below the ship's floor by correctly saving them. " +
+                  "Disable this when FixItemsLoadingSameRotation is true in ShaosilGaming's GeneralImprovements mod.");
             OutOfBounds.VerticalOffset = config.Bind("OutOfBounds", "vertical_offset", 0.01f
-                , new ConfigDescription("vertical offset to apply to objects on load to prevent them from clipping into the floor", new AcceptableValueRange<float>(0.001f,1f)));
+                , new ConfigDescription("Vertical offset to apply to objects on load to prevent them from clipping into the ship's floor", new AcceptableValueRange<float>(0.001f,1f)));
             OutOfBounds.SpawnInFurniture = config.Bind("OutOfBounds", "spawn_in_furniture", true
                 , "Fix items generating inside furniture ( eg: lamps inside the kitchen counter )");
             //AlternateLightningParticles
@@ -102,6 +105,7 @@ internal partial class MattyFixes
                 LethalConfigProxy.AddConfig(ItemClipping.VerticalOffset);
                 LethalConfigProxy.AddConfig(ItemClipping.ManualOffsets, true);
                 LethalConfigProxy.AddConfig(OutOfBounds.Enabled, true);
+                LethalConfigProxy.AddConfig(OutOfBounds.SaveItemsInShip, true);
                 LethalConfigProxy.AddConfig(OutOfBounds.VerticalOffset);
                 LethalConfigProxy.AddConfig(OutOfBounds.SpawnInFurniture, true);
                 LethalConfigProxy.AddConfig(LightingParticle.Enabled, true);
@@ -162,6 +166,7 @@ internal partial class MattyFixes
         internal static class OutOfBounds
         {
             internal static ConfigEntry<bool> Enabled;
+            internal static ConfigEntry<bool> SaveItemsInShip;
             internal static ConfigEntry<float> VerticalOffset;
             internal static ConfigEntry<bool> SpawnInFurniture;
         }


### PR DESCRIPTION
Edit of my (closed) previous PR.

This small PR does two things.
First, it adds a new `OutOfBounds.save_items_in_ship` configuration setting  which controls whether to patch `GameNetworkManager.SaveItemsInShip`'s opcodes.

Secondly, it makes  [SaveItemsCorrectly](https://github.com/mattymatty97/LTC_MattyFixes/blob/e952745c2805686e0c950dfa8b222c43f0681f8c/Plugin/src/Patches/OutOfBoundsItemsFix.cs#L69) exit early when either one of `enabled` or `save_items_in_ship` setting is `false` thus leaving the original function's code unchanged. This allows the [`FixItemsLoadingSameRotation` patch](https://github.com/Shaosil/LethalCompanyMods-GeneralImprovements/blob/d16be720797d84a937be1291666f81dcffd02611/Patches/GameNetworkManagerPatch.cs#L109) in [Shaosil's GeneralImprovements mod](https://github.com/Shaosil/LethalCompanyMods-GeneralImprovements/tree/master) to work properly. As a reminder, his patch allows the ship items' rotation to be saved in the save data.

The only downside of having this check in `SaveItemsCorrectly` is now the user has to reboot the game after enabling either one of `enabled` or `save_items_in_ship` when either of them or both were disabled at game boot.